### PR TITLE
fix(Pino): String message parameter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "packages/*"
       ],
       "dependencies": {
-        "@sapphire/framework": "^3.0.0-next.838919c.0"
+        "@sapphire/framework": "^3.0.0-next.838919c.0",
+        "pino-pretty": "^8.0.0"
       },
       "devDependencies": {
         "@hazmi35/eslint-config": "^8.4.2",
@@ -3379,6 +3380,100 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/args": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/args/-/args-5.0.1.tgz",
+      "integrity": "sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==",
+      "dependencies": {
+        "camelcase": "5.0.0",
+        "chalk": "2.4.2",
+        "leven": "2.1.0",
+        "mri": "1.1.4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/args/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/args/node_modules/camelcase": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+      "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/args/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/args/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/args/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/args/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/args/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/args/node_modules/leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/args/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/array-differ": {
       "version": "3.0.0",
       "dev": true,
@@ -3971,6 +4066,11 @@
       "bin": {
         "color-support": "bin.js"
       }
+    },
+    "node_modules/colorette": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.17.tgz",
+      "integrity": "sha512-hJo+3Bkn0NCHybn9Tu35fIeoOKGOk5OCC32y4Hz2It+qlCO2Q3DeQ1hRn/tDDMQKRYUEzqsl7jbF6dYKjlE60g=="
     },
     "node_modules/columnify": {
       "version": "1.6.0",
@@ -4894,6 +4994,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/fast-copy": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.3.tgz",
+      "integrity": "sha512-LDzYKNTHhD+XOp8wGMuCkY4eTxFZOOycmpwLBiuF3r3OjOmZnURRD8t2dUAbmKuXGbo/MGggwbSjcBdp8QT0+g=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "license": "MIT"
@@ -4941,6 +5046,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -6785,6 +6895,14 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "dev": true,
@@ -7582,6 +7700,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -8683,6 +8809,50 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/pino-pretty": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-8.0.0.tgz",
+      "integrity": "sha512-6Zn+2HBc8ZXEJb1XYZfY0Kh0jVBeKxmu077BzE0wzJZzQwNffmdQbIH7bNe0WPLjLApnVTx8TvvR8UNUcgE4nA==",
+      "dependencies": {
+        "args": "5.0.1",
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^2.1.1",
+        "fast-safe-stringify": "^2.0.7",
+        "joycon": "^3.1.1",
+        "on-exit-leak-free": "^0.2.0",
+        "pino-abstract-transport": "^0.5.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^3.6.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^2.2.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/on-exit-leak-free": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="
+    },
+    "node_modules/pino-pretty/node_modules/sonic-boom": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
+      "integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/pino-std-serializers": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-5.5.0.tgz",
@@ -8833,6 +9003,15 @@
       "version": "1.4.8",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -9376,6 +9555,11 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/secure-json-parse": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.4.0.tgz",
+      "integrity": "sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg=="
+    },
     "node_modules/semver": {
       "version": "7.3.7",
       "dev": true,
@@ -9740,7 +9924,6 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10847,7 +11030,7 @@
     },
     "packages/command-context": {
       "name": "@frutbits/command-context",
-      "version": "1.1.3",
+      "version": "2.0.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@sapphire/decorators": "^4.3.5",
@@ -10865,7 +11048,7 @@
     },
     "packages/pino-logger": {
       "name": "@frutbits/pino-logger",
-      "version": "1.0.4",
+      "version": "2.0.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "pino": "^8.0.0"
@@ -13219,6 +13402,78 @@
       "version": "2.0.1",
       "dev": true
     },
+    "args": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/args/-/args-5.0.1.tgz",
+      "integrity": "sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==",
+      "requires": {
+        "camelcase": "5.0.0",
+        "chalk": "2.4.2",
+        "leven": "2.1.0",
+        "mri": "1.1.4"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "camelcase": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+        },
+        "leven": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+          "integrity": "sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA=="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "array-differ": {
       "version": "3.0.0",
       "dev": true
@@ -13600,6 +13855,11 @@
     "color-support": {
       "version": "1.1.3",
       "dev": true
+    },
+    "colorette": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.17.tgz",
+      "integrity": "sha512-hJo+3Bkn0NCHybn9Tu35fIeoOKGOk5OCC32y4Hz2It+qlCO2Q3DeQ1hRn/tDDMQKRYUEzqsl7jbF6dYKjlE60g=="
     },
     "columnify": {
       "version": "1.6.0",
@@ -14214,6 +14474,11 @@
         "tmp": "^0.0.33"
       }
     },
+    "fast-copy": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.3.tgz",
+      "integrity": "sha512-LDzYKNTHhD+XOp8wGMuCkY4eTxFZOOycmpwLBiuF3r3OjOmZnURRD8t2dUAbmKuXGbo/MGggwbSjcBdp8QT0+g=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3"
     },
@@ -14249,6 +14514,11 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.1.tgz",
       "integrity": "sha512-odVmjC8x8jNeMZ3C+rPMESzXVSEU8tSWSHv9HFxP2mm89G/1WwqhrerJDQm9Zus8X6aoRgQDThKqptdNA6bt+A=="
+    },
+    "fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "fastq": {
       "version": "1.13.0",
@@ -15496,6 +15766,11 @@
         }
       }
     },
+    "joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "dev": true
@@ -16038,6 +16313,11 @@
     "modify-values": {
       "version": "1.0.1",
       "dev": true
+    },
+    "mri": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w=="
     },
     "ms": {
       "version": "2.1.2",
@@ -16782,6 +17062,46 @@
         }
       }
     },
+    "pino-pretty": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-8.0.0.tgz",
+      "integrity": "sha512-6Zn+2HBc8ZXEJb1XYZfY0Kh0jVBeKxmu077BzE0wzJZzQwNffmdQbIH7bNe0WPLjLApnVTx8TvvR8UNUcgE4nA==",
+      "requires": {
+        "args": "5.0.1",
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^2.1.1",
+        "fast-safe-stringify": "^2.0.7",
+        "joycon": "^3.1.1",
+        "on-exit-leak-free": "^0.2.0",
+        "pino-abstract-transport": "^0.5.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^3.6.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^2.2.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "dateformat": {
+          "version": "4.6.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+          "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="
+        },
+        "on-exit-leak-free": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+          "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="
+        },
+        "sonic-boom": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
+          "integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
+          "requires": {
+            "atomic-sleep": "^1.0.0"
+          }
+        }
+      }
+    },
     "pino-std-serializers": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-5.5.0.tgz",
@@ -16876,6 +17196,15 @@
     "protocols": {
       "version": "1.4.8",
       "dev": true
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "punycode": {
       "version": "2.1.1",
@@ -17208,6 +17537,11 @@
       "version": "2.1.2",
       "devOptional": true
     },
+    "secure-json-parse": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.4.0.tgz",
+      "integrity": "sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg=="
+    },
     "semver": {
       "version": "7.3.7",
       "dev": true,
@@ -17445,8 +17779,7 @@
       }
     },
     "strip-json-comments": {
-      "version": "3.1.1",
-      "dev": true
+      "version": "3.1.1"
     },
     "strong-log-transformer": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "typescript": "4.7.3"
   },
   "dependencies": {
-    "@sapphire/framework": "^3.0.0-next.838919c.0"
+    "@sapphire/framework": "^3.0.0-next.838919c.0",
+    "pino-pretty": "^8.0.0"
   }
 }

--- a/packages/pino-logger/src/lib/PinoLogger.ts
+++ b/packages/pino-logger/src/lib/PinoLogger.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable class-methods-use-this */
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 import type { ILogger } from "@sapphire/framework";
@@ -12,28 +13,46 @@ export class PinoLogger implements ILogger {
         this.pino = pino(options);
     }
 
-    public trace(...values: readonly [unknown]): void {
-        this.pino.trace(...values);
+    public trace(object: any, ...values: readonly [unknown]): void {
+        if (typeof object === "string") {
+            return this.pino.trace(...values, object);
+        }
+        return this.pino.trace(object, ...values);
     }
 
-    public debug(...values: readonly [unknown]): void {
-        this.pino.debug(...values);
+    public debug(object: any, ...values: readonly [unknown]): void {
+        if (typeof object === "string") {
+            return this.pino.debug(...values, object);
+        }
+        return this.pino.debug(object, ...values);
     }
 
-    public info(...values: readonly [unknown]): void {
-        this.pino.info(...values);
+    public info(object: any, ...values: readonly [unknown]): void {
+        if (typeof object === "string") {
+            return this.pino.info(...values, object);
+        }
+        return this.pino.info(object, ...values);
     }
 
-    public warn(...values: readonly [unknown]): void {
-        this.pino.warn(...values);
+    public warn(object: any, ...values: readonly [unknown]): void {
+        if (typeof object === "string") {
+            return this.pino.warn(...values, object);
+        }
+        return this.pino.warn(object, ...values);
     }
 
-    public error(...values: readonly [unknown]): void {
-        this.pino.error(...values);
+    public error(object: any, ...values: readonly [unknown]): void {
+        if (typeof object === "string") {
+            return this.pino.error(...values, object);
+        }
+        return this.pino.error(object, ...values);
     }
 
-    public fatal(...values: readonly [unknown]): void {
-        this.pino.fatal(...values);
+    public fatal(object: any, ...values: readonly [unknown]): void {
+        if (typeof object === "string") {
+            return this.pino.fatal(...values, object);
+        }
+        return this.pino.fatal(object, ...values);
     }
 
     public has(): boolean {

--- a/packages/pino-logger/tests/listeners/ready.ts
+++ b/packages/pino-logger/tests/listeners/ready.ts
@@ -8,5 +8,7 @@ import { Listener } from "@sapphire/framework";
 export class ready extends Listener {
     public run(): void {
         this.container.logger.info("Client ready and logged in.");
+        // Test error
+        throw new Error("Hello World");
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/45705890/173325702-56066c7e-023d-4ece-830c-3d1906a19be9.png)
Somehow, any error trace from [@sapphire/framework](https://github.com/sapphiredev/framework) will not trace the error trace. It is because the framework log the error object as second params (REF: https://github.com/sapphiredev/framework/blob/838919cfb1163a145709e5e4c12a9359a99bfab6/src/optional-listeners/error-listeners/CoreChatInputCommandError.ts#L12), meanwhile [pino](https://github.com/pinojs/pino/blob/master/docs/api.md#logger-instance) take this following params instead:
```
logger.error([mergingObject], [message], [...interpolationValues])
```
Reference: https://github.com/pinojs/pino/blob/master/docs/api.md#loggererrormergingobject-message-interpolationvalues